### PR TITLE
Link-checking

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,31 @@
+name: CheckLinks
+on:
+  push:
+    branches:
+      - '**'
+  schedule:
+    - cron: '13 10 * * *'
+
+jobs:
+  checklinks:
+    name: Check Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Setup jekyll and htmlproofer
+        run: | 
+          gem install --no-document jekyll jekyll-redirect-from html-proofer
+
+      - name: Build jekyll website
+        run: jekyll build
+
+      - name: Check for broken links
+        run: |
+          cat .github/workflows/links_to_ignore.txt | htmlproofer --log-level :debug --http-status-ignore 999,301,0 --checks-to-ignore ImageCheck --typhoeus-config='{"headers":{"User-Agent":"Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"},"cookiefile":".cookies","cookiejar":".cookies"}' --url-ignore `xargs` ./_site

--- a/.github/workflows/links_to_ignore.txt
+++ b/.github/workflows/links_to_ignore.txt
@@ -1,0 +1,1 @@
+"/google.com/"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ css/site.css
 *.pdf
 
 .DS_Store
+
+.cookies

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,6 +30,12 @@
           <span class="nav-text">{{ nav | upcase }}</span></a>
       </li>
 
+      {% elsif navURL == "" %}
+      <li class="nav-button">
+        <a href="{{ site.baseurl }}/">
+          <span class="nav-text">{{ nav | upcase }}</span></a>
+      </li>
+
       {% else %}
       <li class="nav-button">
         <a href="{{ site.baseurl }}/{{ navURL }}/">


### PR DESCRIPTION
Closes #1

Adds the same action from visdesignlab/visdesignlab.github.io to check links. The link checker exposed that the home page link was broken and didn't have a proper href. You can verify that it's broken on the main site

The action is still failing because of a link to feed.xml, which doesn't exist. It looks like it would be used for news, but it's not there.